### PR TITLE
Add schedule app tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # create-line
-초기 커밋 – Codex용 베이스
+
+This repository contains a simple `Schedule` class with basic functionality to
+manage events. Unit tests are included under the `tests` directory.
+
+## Running tests
+
+Execute the following command from the project root:
+
+```bash
+python -m unittest
+```
+
+This will discover and run all tests in the `tests` package.

--- a/schedule_app.py
+++ b/schedule_app.py
@@ -1,0 +1,18 @@
+class Schedule:
+    def __init__(self):
+        self.events = []
+
+    def add_event(self, event):
+        if event not in self.events:
+            self.events.append(event)
+            return True
+        return False
+
+    def remove_event(self, event):
+        if event in self.events:
+            self.events.remove(event)
+            return True
+        return False
+
+    def get_events(self):
+        return list(self.events)

--- a/tests/test_schedule_app.py
+++ b/tests/test_schedule_app.py
@@ -1,0 +1,28 @@
+import unittest
+from schedule_app import Schedule
+
+class TestSchedule(unittest.TestCase):
+    def setUp(self):
+        self.schedule = Schedule()
+
+    def test_add_event(self):
+        self.assertTrue(self.schedule.add_event('Meeting'))
+        self.assertIn('Meeting', self.schedule.get_events())
+        # Adding the same event again should fail
+        self.assertFalse(self.schedule.add_event('Meeting'))
+
+    def test_remove_event(self):
+        self.schedule.add_event('Call')
+        self.assertTrue(self.schedule.remove_event('Call'))
+        self.assertNotIn('Call', self.schedule.get_events())
+        # Removing an event that does not exist should return False
+        self.assertFalse(self.schedule.remove_event('Call'))
+
+    def test_get_events_returns_copy(self):
+        self.schedule.add_event('Lunch')
+        events = self.schedule.get_events()
+        events.append('Dinner')
+        self.assertNotIn('Dinner', self.schedule.get_events())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `Schedule` class implementation
- write unit tests for `Schedule` in `tests/test_schedule_app.py`
- add `tests/__init__.py` for discovery
- update README with how to run tests

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_684649f26eac8327863c9277bf7f4f11